### PR TITLE
feat(i18n): add fa-IR locale

### DIFF
--- a/packages/twenty-shared/src/translations/constants/AppLocales.ts
+++ b/packages/twenty-shared/src/translations/constants/AppLocales.ts
@@ -11,6 +11,7 @@ export const APP_LOCALES = {
   'de-DE': 'de-DE',
   'el-GR': 'el-GR',
   'es-ES': 'es-ES',
+  'fa-IR': 'fa-IR',
   'fi-FI': 'fi-FI',
   'fr-FR': 'fr-FR',
   'he-IL': 'he-IL',


### PR DESCRIPTION
## Summary
- include Persian `fa-IR` in app locale list

## Testing
- `npx @lingui/cli extract --config packages/twenty-front/lingui.config.ts && npx @lingui/cli compile --config packages/twenty-front/lingui.config.ts` *(fails: Cannot find module '@lingui/conf')*


------
https://chatgpt.com/codex/tasks/task_b_68bc895316d0832d82061aee030e01c3