### PR TITLE
feat(i18n): add Persian font support

### DIFF
--- a/packages/twenty-front/src/index.css
+++ b/packages/twenty-front/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;500;600;700&display=swap');
+
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
@@ -7,6 +9,12 @@ body {
 
 html {
   font-size: 13px;
+  font-family: 'Inter', sans-serif;
+}
+
+html[lang='fa-IR'],
+html[lang='fa-IR'] body {
+  font-family: 'Vazirmatn', sans-serif;
 }
 
 button {

--- a/packages/twenty-front/src/utils/i18n/dynamicActivate.ts
+++ b/packages/twenty-front/src/utils/i18n/dynamicActivate.ts
@@ -10,4 +10,7 @@ export const dynamicActivate = async (locale: keyof typeof APP_LOCALES) => {
   const { messages } = await import(`../../locales/generated/${locale}.ts`);
   i18n.load(locale, messages);
   i18n.activate(locale);
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = locale;
+  }
 };


### PR DESCRIPTION
## Summary
- import Vazirmatn font and apply when locale is fa-IR
- set html lang attribute during dynamic locale activation

## Testing
- `npx nx lint twenty-front` *(fails: yarn.lock indentation error)*
- `npx nx test twenty-front` *(fails: yarn.lock indentation error)*

------
https://chatgpt.com/codex/tasks/task_b_68bd2c6892b8832d936337371c4d16de