### PR TITLE
feat(i18n): add RTL locale utilities

### DIFF
--- a/packages/twenty-front/src/hooks/__tests__/useRtl.test.tsx
+++ b/packages/twenty-front/src/hooks/__tests__/useRtl.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { enUS } from 'date-fns/locale';
+import type { ReactNode } from 'react';
+
+import { dateLocaleState } from '~/localization/states/dateLocaleState';
+import { useRtl } from '../useRtl';
+
+describe('useRtl', () => {
+  beforeEach(() => {
+    document.documentElement.dir = '';
+  });
+
+  it('sets document direction to rtl when locale is rtl', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set(dateLocaleState, { locale: 'fa-IR', localeCatalog: enUS });
+        }}
+      >
+        {children}
+      </RecoilRoot>
+    );
+
+    renderHook(() => useRtl(), { wrapper });
+
+    expect(document.documentElement.dir).toBe('rtl');
+  });
+
+  it('sets document direction to ltr when locale is not rtl', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set(dateLocaleState, { locale: 'en-US', localeCatalog: enUS });
+        }}
+      >
+        {children}
+      </RecoilRoot>
+    );
+
+    renderHook(() => useRtl(), { wrapper });
+
+    expect(document.documentElement.dir).toBe('ltr');
+  });
+});

--- a/packages/twenty-front/src/hooks/useRtl.ts
+++ b/packages/twenty-front/src/hooks/useRtl.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { isRtlLocale } from 'twenty-shared/utils';
+
+import { dateLocaleState } from '~/localization/states/dateLocaleState';
+
+/**
+ * Hook that synchronises the document direction with the current locale.
+ *
+ * When the locale is RTL the document's `dir` attribute is set to `rtl`,
+ * otherwise it defaults to `ltr`.
+ */
+export const useRtl = () => {
+  const { locale } = useRecoilValue(dateLocaleState);
+
+  useEffect(() => {
+    document.documentElement.dir =
+      locale && isRtlLocale(locale) ? 'rtl' : 'ltr';
+  }, [locale]);
+};

--- a/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
+++ b/packages/twenty-front/src/modules/app/components/AppRouterProviders.tsx
@@ -24,6 +24,7 @@ import { PageTitle } from '@/ui/utilities/page-title/components/PageTitle';
 import { UserProvider } from '@/users/components/UserProvider';
 import { UserProviderEffect } from '@/users/components/UserProviderEffect';
 import { WorkspaceProviderEffect } from '@/workspace/components/WorkspaceProviderEffect';
+import { RtlEffect } from '@/app/effect-components/RtlEffect';
 import { StrictMode } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { getPageTitleFromPath } from '~/utils/title-utils';
@@ -49,6 +50,7 @@ export const AppRouterProviders = () => {
                     <ObjectMetadataItemsProvider>
                       <PrefetchDataProvider>
                         <UserThemeProviderEffect />
+                        <RtlEffect />
                         <SnackBarProvider>
                           <ErrorMessageEffect />
                           <DialogComponentInstanceContext.Provider

--- a/packages/twenty-front/src/modules/app/effect-components/RtlEffect.tsx
+++ b/packages/twenty-front/src/modules/app/effect-components/RtlEffect.tsx
@@ -1,0 +1,6 @@
+import { useRtl } from '~/hooks/useRtl';
+
+export const RtlEffect = () => {
+  useRtl();
+  return null;
+};

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistInput.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsBlocklistInput.tsx
@@ -17,7 +17,7 @@ const StyledContainer = styled.div`
 
 const StyledLinkContainer = styled.div`
   flex: 1;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 type SettingsAccountsBlocklistInputProps = {

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsRadioSettingsCard.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsRadioSettingsCard.tsx
@@ -36,7 +36,7 @@ const StyledDescription = styled.div`
 `;
 
 const StyledRadio = styled(Radio)`
-  margin-left: auto;
+  margin-inline-start: auto;
 `;
 
 export const SettingsAccountsRadioSettingsCard = <

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsToggleSettingCard.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsToggleSettingCard.tsx
@@ -36,7 +36,7 @@ const StyledDescription = styled.div`
 `;
 
 const StyledToggle = styled(Toggle)`
-  margin-left: auto;
+  margin-inline-start: auto;
 `;
 
 export const SettingsAccountsToggleSettingCard = ({

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsVisibilityIcon.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsAccountsVisibilityIcon.tsx
@@ -23,7 +23,7 @@ const StyledSubjectSkeleton = styled.div<{ isActive?: boolean }>`
 `;
 
 const StyledMetadataSkeleton = styled(StyledSubjectSkeleton)`
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledBodySkeleton = styled(StyledSubjectSkeleton)`

--- a/packages/twenty-front/src/modules/settings/accounts/components/SettingsConnectedAccountsTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/accounts/components/SettingsConnectedAccountsTableHeader.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Trans } from '@lingui/react/macro';
 
 const StyledTableHeader = styled(TableHeader)`
-  padding-right: ${({ theme }) => theme.spacing(14)};
+  padding-inline-end: ${({ theme }) => theme.spacing(14)};
 `;
 
 export const SettingsConnectedAccountsTableHeader = () => {

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthAccountSyncCountersTable.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/SettingsAdminHealthAccountSyncCountersTable.tsx
@@ -4,8 +4,8 @@ import { H2Title } from 'twenty-ui/display';
 import { Section } from 'twenty-ui/layout';
 
 const StyledSettingsAdminTableCard = styled(SettingsAdminTableCard)`
-  padding-left: ${({ theme }) => theme.spacing(2)};
-  padding-right: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
+  padding-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 export const SettingsAdminHealthAccountSyncCountersTable = ({

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/WorkerMetricsGraph.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/WorkerMetricsGraph.tsx
@@ -29,8 +29,8 @@ const StyledNoDataMessage = styled.div`
 `;
 
 const StyledSettingsAdminTableCard = styled(SettingsAdminTableCard)`
-  padding-left: ${({ theme }) => theme.spacing(2)};
-  padding-right: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
+  padding-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 type WorkerMetricsGraphProps = {

--- a/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/WorkerMetricsTooltip.tsx
+++ b/packages/twenty-front/src/modules/settings/admin-panel/health-status/components/WorkerMetricsTooltip.tsx
@@ -25,7 +25,7 @@ const StyledTooltipColorCircle = styled.div<{ color: string }>`
   background-color: ${({ color }) => color};
   border-radius: 50%;
   height: 8px;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
   width: 8px;
 `;
 

--- a/packages/twenty-front/src/modules/settings/components/AdvancedSettingsContentWrapperWithDot.tsx
+++ b/packages/twenty-front/src/modules/settings/components/AdvancedSettingsContentWrapperWithDot.tsx
@@ -18,7 +18,7 @@ const StyledDotContainer = styled.div<{ dotPosition: DotPosition }>`
   display: flex;
   position: absolute;
   height: 100%;
-  left: ${({ theme }) => theme.spacing(-5)};
+  inset-inline-start: ${({ theme }) => theme.spacing(-5)};
 
   ${({ dotPosition }) => {
     if (dotPosition === 'top') {
@@ -33,7 +33,7 @@ const StyledDotContainer = styled.div<{ dotPosition: DotPosition }>`
 `;
 
 const StyledIconPoint = styled(IconPoint)`
-  margin-right: 0;
+  margin-inline-end: 0;
 `;
 
 export const AdvancedSettingsContentWrapperWithDot = ({

--- a/packages/twenty-front/src/modules/settings/components/Separator.tsx
+++ b/packages/twenty-front/src/modules/settings/components/Separator.tsx
@@ -4,8 +4,8 @@ const StyledHr = styled.hr`
   border: none;
   border-top: 1px solid ${({ theme }) => theme.border.color.light};
   margin: 0px;
-  margin-left: ${({ theme }) => theme.spacing(4)};
-  margin-right: ${({ theme }) => theme.spacing(4)};
+  margin-inline-start: ${({ theme }) => theme.spacing(4)};
+  margin-inline-end: ${({ theme }) => theme.spacing(4)};
 `;
 
 export const Separator = () => {

--- a/packages/twenty-front/src/modules/settings/components/SettingsCard.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsCard.tsx
@@ -58,11 +58,14 @@ const StyledTitle = styled.div<{ disabled?: boolean }>`
 
 const StyledIconChevronRight = styled(IconChevronRight)`
   color: ${({ theme }) => theme.font.color.light};
+  [dir='rtl'] & {
+    transform: scaleX(-1);
+  }
 `;
 
 const StyledDescription = styled.div`
   padding-bottom: ${({ theme }) => theme.spacing(2)};
-  padding-left: ${({ theme }) => theme.spacing(7)};
+  padding-inline-start: ${({ theme }) => theme.spacing(7)};
 `;
 
 const StyledIconContainer = styled.div`

--- a/packages/twenty-front/src/modules/settings/components/SettingsCounter.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsCounter.tsx
@@ -16,7 +16,7 @@ const StyledCounterContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
-  margin-left: auto;
+  margin-inline-start: auto;
   width: ${({ theme }) => theme.spacing(30)};
 `;
 

--- a/packages/twenty-front/src/modules/settings/components/SettingsListCard.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListCard.tsx
@@ -22,7 +22,7 @@ const StyledButton = styled.button`
   color: ${({ theme }) => theme.font.color.secondary};
   gap: ${({ theme }) => theme.spacing(2)};
   padding: 0 ${({ theme }) => theme.spacing(1)};
-  padding-left: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
   cursor: pointer;
   display: flex;
   flex: 1 0 0;

--- a/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
@@ -17,7 +17,7 @@ const StyledRow = styled(CardContent, {
   font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
   padding: ${({ theme }) => theme.spacing(2)};
-  padding-left: ${({ theme }) => theme.spacing(3)};
+  padding-inline-start: ${({ theme }) => theme.spacing(3)};
   min-height: ${({ theme }) => theme.spacing(6)};
 
   &:hover {
@@ -32,6 +32,12 @@ const StyledRightContainer = styled.div`
   gap: ${({ theme }) => theme.spacing(1)};
 `;
 
+const StyledIconChevronRight = styled(IconChevronRight)`
+  [dir='rtl'] & {
+    transform: scaleX(-1);
+  }
+`;
+
 const StyledContent = styled.div`
   flex: 1 0 auto;
   display: flex;
@@ -41,7 +47,7 @@ const StyledContent = styled.div`
 const StyledDescription = styled.span`
   color: ${({ theme }) => theme.font.color.light};
   font-weight: ${({ theme }) => theme.font.weight.regular};
-  padding-left: ${({ theme }) => theme.spacing(1)};
+  padding-inline-start: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledLink = styled(Link)`
@@ -87,7 +93,7 @@ export const SettingsListItemCardContent = ({
       <StyledRightContainer>
         {rightComponent}
         {!!to && (
-          <IconChevronRight
+          <StyledIconChevronRight
             size={theme.icon.size.md}
             color={theme.font.color.tertiary}
           />

--- a/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentSelect.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentSelect.tsx
@@ -18,7 +18,7 @@ type SettingsOptionCardContentSelectProps = {
 
 const StyledSelectContainer = styled.div`
   justify-content: flex-end;
-  margin-left: auto;
+  margin-inline-start: auto;
   max-width: 120px;
 `;
 

--- a/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentToggle.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsOptions/SettingsOptionCardContentToggle.tsx
@@ -29,7 +29,7 @@ const StyledSettingsOptionCardToggleButton = styled(Toggle)<{
 }>`
   align-self: ${({ toggleCentered }) =>
     toggleCentered ? 'center' : 'flex-start'};
-  margin-left: auto;
+  margin-inline-start: auto;
 `;
 
 const StyledSettingsOptionCardToggleCover = styled.span`

--- a/packages/twenty-front/src/modules/settings/components/SettingsRadioCard.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsRadioCard.tsx
@@ -20,7 +20,7 @@ const StyledRadioCardContent = styled(CardContent)`
 `;
 
 const StyledRadio = styled(Radio)`
-  margin-left: auto;
+  margin-inline-start: auto;
   padding: ${({ theme }) => theme.spacing(1)};
 `;
 

--- a/packages/twenty-front/src/modules/settings/components/SettingsSummaryCard.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsSummaryCard.tsx
@@ -20,7 +20,7 @@ const StyledTitle = styled.div`
   display: flex;
   font-weight: ${({ theme }) => theme.font.weight.medium};
   gap: ${({ theme }) => theme.spacing(2)};
-  margin-right: auto;
+  margin-inline-end: auto;
 `;
 
 export const SettingsSummaryCard = ({

--- a/packages/twenty-front/src/modules/settings/data-model/components/SettingsDataModelNewFieldBreadcrumbDropDown.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/components/SettingsDataModelNewFieldBreadcrumbDropDown.tsx
@@ -30,7 +30,7 @@ const StyledButtonContainer = styled.div`
 const StyledDownChevron = styled(IconChevronDown)`
   color: ${({ theme }) => theme.font.color.primary};
   position: absolute;
-  right: ${({ theme }) => theme.spacing(1.5)};
+  inset-inline-end: ${({ theme }) => theme.spacing(1.5)};
   top: 50%;
   transform: translateY(-50%);
 `;
@@ -56,12 +56,12 @@ const StyledMenuItem = styled(MenuItem)<{
 `;
 
 const StyledSpan = styled.span`
-  margin-left: ${({ theme }) => theme.spacing(2)};
+  margin-inline-start: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledButton = styled(Button)`
   color: ${({ theme }) => theme.font.color.primary};
-  padding-right: ${({ theme }) => theme.spacing(6)};
+  padding-inline-end: ${({ theme }) => theme.spacing(6)};
 `;
 
 export const SettingsDataModelNewFieldBreadcrumbDropDown = () => {

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectForm.tsx
@@ -60,7 +60,7 @@ const StyledOptionsLabel = styled.div<{
   margin-bottom: ${({ theme }) => theme.spacing(1.5)};
   margin-top: ${({ theme }) => theme.spacing(1)};
   width: 100%;
-  margin-left: ${({ theme, isAdvancedModeEnabled }) =>
+  margin-inline-start: ${({ theme, isAdvancedModeEnabled }) =>
     theme.spacing(isAdvancedModeEnabled ? 10 : 0)};
 `;
 
@@ -85,7 +85,7 @@ const StyledLabelContainer = styled.div`
 `;
 
 const StyledIconContainer = styled.div`
-  border-right: 1px solid ${MAIN_COLORS.yellow};
+  border-inline-end: 1px solid ${MAIN_COLORS.yellow};
   display: flex;
 
   margin-bottom: ${({ theme }) => theme.spacing(1.5)};
@@ -93,7 +93,7 @@ const StyledIconContainer = styled.div`
 `;
 
 const StyledIconPoint = styled(IconPoint)`
-  margin-right: ${({ theme }) => theme.spacing(0.5)};
+  margin-inline-end: ${({ theme }) => theme.spacing(0.5)};
 `;
 
 const StyledFooter = styled(CardFooter)`

--- a/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/fields/forms/select/components/SettingsDataModelFieldSelectFormOptionRow.tsx
@@ -46,8 +46,8 @@ const StyledColorSample = styled(ColorSample)`
   margin-top: ${({ theme }) => theme.spacing(1)};
   margin-bottom: ${({ theme }) => theme.spacing(1)};
 
-  margin-right: ${({ theme }) => theme.spacing(3.5)};
-  margin-left: ${({ theme }) => theme.spacing(3.5)};
+  margin-inline-end: ${({ theme }) => theme.spacing(3.5)};
+  margin-inline-start: ${({ theme }) => theme.spacing(3.5)};
 `;
 
 const StyledOptionInput = styled(SettingsTextInput)`
@@ -59,11 +59,11 @@ const StyledOptionInput = styled(SettingsTextInput)`
 `;
 
 const StyledIconGripVertical = styled(IconGripVertical)`
-  margin-right: ${({ theme }) => theme.spacing(0.75)};
+  margin-inline-end: ${({ theme }) => theme.spacing(0.75)};
 `;
 
 const StyledLightIconButton = styled(LightIconButton)`
-  margin-left: ${({ theme }) => theme.spacing(2)};
+  margin-inline-start: ${({ theme }) => theme.spacing(2)};
 `;
 
 export const SettingsDataModelFieldSelectFormOptionRow = ({

--- a/packages/twenty-front/src/modules/settings/data-model/new-object/components/SettingsAvailableStandardObjectItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/new-object/components/SettingsAvailableStandardObjectItemTableRow.tsx
@@ -20,7 +20,7 @@ export const StyledAvailableStandardObjectTableRow = styled(TableRow)`
 const StyledCheckboxTableCell = styled(TableCell)`
   justify-content: center;
   padding: 0;
-  padding-left: ${({ theme }) => theme.spacing(1)};
+  padding-inline-start: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledNameTableCell = styled(TableCell)`

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectFieldItemTableRow.tsx
@@ -53,7 +53,7 @@ const StyledNameLabel = styled.div`
 
 const StyledIconTableCell = styled(TableCell)`
   justify-content: center;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 export const SettingsObjectFieldItemTableRow = ({

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/SettingsObjectItemTableRow.tsx
@@ -33,7 +33,7 @@ const StyledNameLabel = styled.div`
 
 const StyledActionTableCell = styled(TableCell)`
   justify-content: center;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 export const SettingsObjectMetadataItemTableRow = ({

--- a/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/object-details/components/tabs/ObjectSettings.tsx
@@ -22,7 +22,7 @@ const StyledContentContainer = styled.div`
 `;
 
 const StyledFormSection = styled(Section)`
-  padding-left: 0 !important;
+  padding-inline-start: 0 !important;
 `;
 
 export const ObjectSettings = ({ objectMetadataItem }: ObjectSettingsProps) => {

--- a/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsDataModelObjectSummary.tsx
+++ b/packages/twenty-front/src/modules/settings/data-model/objects/components/SettingsDataModelObjectSummary.tsx
@@ -37,7 +37,7 @@ const StyledOverflowingTextWithTooltip = styled.div`
 
 const StyledNumber = styled.div`
   color: ${({ theme }) => theme.font.color.tertiary};
-  padding-right: ${({ theme }) => theme.spacing(2)};
+  padding-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledIconContainer = styled.div`

--- a/packages/twenty-front/src/modules/settings/developers/components/ApiKeyInput.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/ApiKeyInput.tsx
@@ -12,7 +12,7 @@ const StyledContainer = styled.div`
 
 const StyledLinkContainer = styled.div`
   flex: 1;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 type ApiKeyInputProps = { apiKey: string };

--- a/packages/twenty-front/src/modules/settings/developers/components/ApiKeyNameInput.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/ApiKeyNameInput.tsx
@@ -10,7 +10,7 @@ const StyledComboInputContainer = styled.div`
   display: flex;
   flex-direction: row;
   > * + * {
-    margin-left: ${({ theme }) => theme.spacing(4)};
+    margin-inline-start: ${({ theme }) => theme.spacing(4)};
   }
 `;
 

--- a/packages/twenty-front/src/modules/settings/developers/components/SettingsDevelopersWebhookTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/developers/components/SettingsDevelopersWebhookTableRow.tsx
@@ -13,8 +13,8 @@ export const StyledApisFieldTableRow = styled(TableRow)`
 
 const StyledIconTableCell = styled(TableCell)`
   justify-content: center;
-  padding-right: ${({ theme }) => theme.spacing(1)};
-  padding-left: 0;
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
+  padding-inline-start: 0;
 `;
 
 const StyledUrlTableCell = styled(TableCell)`
@@ -25,6 +25,9 @@ const StyledUrlTableCell = styled(TableCell)`
 
 const StyledIconChevronRight = styled(IconChevronRight)`
   color: ${({ theme }) => theme.font.color.tertiary};
+  [dir='rtl'] & {
+    transform: scaleX(-1);
+  }
 `;
 
 export const SettingsDevelopersWebhookTableRow = ({

--- a/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomainRecords.tsx
+++ b/packages/twenty-front/src/modules/settings/domains/components/SettingsCustomDomainRecords.tsx
@@ -25,14 +25,16 @@ const StyledTable = styled(Table)`
 const StyledTableCell = styled(TableCell)`
   overflow: hidden;
   display: block;
-  padding: 0 ${({ theme }) => theme.spacing(3)} 0 0;
+  padding-block: 0;
+  padding-inline-end: ${({ theme }) => theme.spacing(3)};
+  padding-inline-start: 0;
 
   &:first-of-type {
-    padding-left: 0;
+    padding-inline-start: 0;
   }
 
   &:last-of-type {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
 `;
 

--- a/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
+++ b/packages/twenty-front/src/modules/settings/profile/components/NameFields.tsx
@@ -15,7 +15,7 @@ const StyledComboInputContainer = styled.div`
   display: flex;
   flex-direction: row;
   > * + * {
-    margin-left: ${({ theme }) => theme.spacing(4)};
+    margin-inline-start: ${({ theme }) => theme.spacing(4)};
   }
 `;
 

--- a/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/components/SettingsRolesTableRow.tsx
@@ -34,10 +34,10 @@ const StyledAvatarGroup = styled.div`
   justify-content: flex-end;
 
   > * {
-    margin-left: -5px;
+    margin-inline-start: -5px;
 
     &:first-of-type {
-      margin-left: 0;
+      margin-inline-start: 0;
     }
   }
 `;
@@ -52,6 +52,12 @@ const StyledTableRow = styled(TableRow)`
   &:hover {
     background: ${({ theme }) => theme.background.transparent.light};
     cursor: pointer;
+  }
+`;
+
+const StyledIconChevronRight = styled(IconChevronRight)`
+  [dir='rtl'] & {
+    transform: scaleX(-1);
   }
 `;
 
@@ -125,7 +131,7 @@ export const SettingsRolesTableRow = ({ role }: SettingsRolesTableRowProps) => {
         <StyledAssignedText>{role.workspaceMembers.length}</StyledAssignedText>
       </TableCell>
       <TableCell align="right" color={theme.font.color.tertiary}>
-        <IconChevronRight size={theme.icon.size.md} />
+        <StyledIconChevronRight size={theme.icon.size.md} />
       </TableCell>
     </StyledTableRow>
   );

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/field-permissions/components/SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow.tsx
@@ -21,13 +21,13 @@ const StyledSectionHeader = styled.div`
 
   height: ${({ theme }) => theme.spacing(6)};
 
-  padding-left: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledCheckboxContainer = styled.div`
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 export const SettingsRolePermissionsObjectLevelObjectFieldPermissionTableAllHeaderRow =

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/object-level-permissions/object-form/components/SettingsRolePermissionsObjectLevelObjectFormObjectLevelTableRow.tsx
@@ -26,7 +26,7 @@ const StyledPermissionCell = styled(TableCell)`
   display: flex;
   flex: 1;
   gap: ${({ theme }) => theme.spacing(1)};
-  padding-left: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledPermissionContent = styled.div`
@@ -50,7 +50,7 @@ const StyledCheckboxCell = styled(TableCell)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 type OverridableCheckboxType = 'no_cta' | 'default' | 'override';

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableHeader.tsx
@@ -15,7 +15,7 @@ const StyledActionsHeader = styled(TableHeader)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 type SettingsRolePermissionsObjectsTableHeaderProps = {

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/objects-permissions/components/SettingsRolePermissionsObjectsTableRow.tsx
@@ -13,7 +13,7 @@ const StyledPermissionCell = styled(TableCell)`
   display: flex;
   flex: 1;
   gap: ${({ theme }) => theme.spacing(1)};
-  padding-left: ${({ theme }) => theme.spacing(2)};
+  padding-inline-start: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledPermissionContent = styled.div`
@@ -36,7 +36,7 @@ const StyledCheckboxCell = styled(TableCell)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledTableRow = styled(TableRow)<{ isDisabled: boolean }>`

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableHeader.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableHeader.tsx
@@ -19,7 +19,7 @@ const StyledActionsHeader = styled(TableHeader)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 export const SettingsRolePermissionsSettingsTableHeader = ({

--- a/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/roles/role-permissions/permission-flags/components/SettingsRolePermissionsSettingsTableRow.tsx
@@ -31,7 +31,7 @@ const StyledCheckboxCell = styled(TableCell)`
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledIconContainer = styled.div`

--- a/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOOIDCForm.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOOIDCForm.tsx
@@ -24,7 +24,7 @@ const StyledContainer = styled.div`
 
 const StyledLinkContainer = styled.div`
   flex: 1;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledButtonCopy = styled.div`

--- a/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOSAMLForm.tsx
+++ b/packages/twenty-front/src/modules/settings/security/components/SSO/SettingsSSOSAMLForm.tsx
@@ -46,7 +46,7 @@ const StyledContainer = styled.div`
 
 const StyledLinkContainer = styled.div`
   flex: 1;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledButtonCopy = styled.div`

--- a/packages/twenty-front/src/modules/settings/serverless-functions/components/SettingsServerlessFunctionsFieldItemTableRow.tsx
+++ b/packages/twenty-front/src/modules/settings/serverless-functions/components/SettingsServerlessFunctionsFieldItemTableRow.tsx
@@ -16,11 +16,14 @@ const StyledNameTableCell = styled(TableCell)`
 
 const StyledIconTableCell = styled(TableCell)`
   justify-content: center;
-  padding-right: ${({ theme }) => theme.spacing(1)};
+  padding-inline-end: ${({ theme }) => theme.spacing(1)};
 `;
 
 const StyledIconChevronRight = styled(IconChevronRight)`
   color: ${({ theme }) => theme.font.color.tertiary};
+  [dir='rtl'] & {
+    transform: scaleX(-1);
+  }
 `;
 
 export const SettingsServerlessFunctionsFieldItemTableRow = ({

--- a/packages/twenty-front/src/modules/settings/workspace/components/NameField.tsx
+++ b/packages/twenty-front/src/modules/settings/workspace/components/NameField.tsx
@@ -16,7 +16,7 @@ const StyledComboInputContainer = styled.div`
   display: flex;
   flex-direction: row;
   > * + * {
-    margin-left: ${({ theme }) => theme.spacing(4)};
+    margin-inline-start: ${({ theme }) => theme.spacing(4)};
   }
 `;
 

--- a/packages/twenty-shared/src/utils/__tests__/isRtlLocale.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/isRtlLocale.test.ts
@@ -1,0 +1,15 @@
+import { isRtlLocale } from '../isRtlLocale';
+
+describe('isRtlLocale', () => {
+  it('returns true for rtl locales', () => {
+    expect(isRtlLocale('fa')).toBe(true);
+    expect(isRtlLocale('fa-IR')).toBe(true);
+    expect(isRtlLocale('ar')).toBe(true);
+  });
+
+  it('returns false for non-rtl locales', () => {
+    expect(isRtlLocale('en')).toBe(false);
+    expect(isRtlLocale('en-US')).toBe(false);
+    expect(isRtlLocale(undefined)).toBe(false);
+  });
+});

--- a/packages/twenty-shared/src/utils/index.ts
+++ b/packages/twenty-shared/src/utils/index.ts
@@ -24,6 +24,7 @@ export {
   getLogoUrlFromDomainName,
 } from './image/getLogoUrlFromDomainName';
 export { getUniqueConstraintsFields } from './indexMetadata/getUniqueConstraintsFields';
+export { isRtlLocale } from './isRtlLocale';
 export { parseJson } from './parseJson';
 export { removePropertiesFromRecord } from './removePropertiesFromRecord';
 export { removeUndefinedFields } from './removeUndefinedFields';

--- a/packages/twenty-shared/src/utils/isRtlLocale.ts
+++ b/packages/twenty-shared/src/utils/isRtlLocale.ts
@@ -1,0 +1,28 @@
+import { isDefined } from './validation/isDefined';
+
+/**
+ * Determines whether a given locale is a Right-To-Left (RTL) locale.
+ *
+ * The check is performed using a list of common RTL language codes. The
+ * comparison is case-insensitive and matches locale prefixes, so `fa` and
+ * `fa-IR` will both return `true`.
+ */
+export const isRtlLocale = (locale: string | undefined | null): boolean => {
+  if (!isDefined(locale)) {
+    return false;
+  }
+
+  const rtlLocales = [
+    'ar', // Arabic
+    'fa', // Persian / Farsi
+    'he', // Hebrew
+    'ur', // Urdu
+    'ps', // Pashto
+    'sd', // Sindhi
+    'ug', // Uyghur
+  ];
+
+  const lowerCaseLocale = locale.toLowerCase();
+
+  return rtlLocales.some((rtlLocale) => lowerCaseLocale.startsWith(rtlLocale));
+};


### PR DESCRIPTION
## Summary
- add RTL locale detection and hook
- use logical CSS properties and flip icons for RTL

## Testing
- `npx nx lint twenty-shared`
- `npx nx lint twenty-front` *(fails: package doesn't seem to be present in lockfile)*
- `npx nx test twenty-shared` *(fails: bad indentation of mapping entry in yarn.lock)*
- `npx nx test twenty-front` *(fails: package doesn't seem to be present in lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_68bd316a4b50832d8e621e07503ba44f