### PR TITLE
test(i18n): cover fa-IR locale utilities

### DIFF
--- a/packages/twenty-front/src/modules/localization/utils/__tests__/formatDateJalali.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/formatDateJalali.test.ts
@@ -12,4 +12,10 @@ describe('formatDateJalali', () => {
     const iso = formatDateJalali(jalali, { locale: 'fa-IR', parse: true });
     expect(iso).toBe('2024-03-20T00:00:00.000Z');
   });
+
+  it('returns ISO date string when locale is LTR', () => {
+    const iso = '2024-03-20T00:00:00.000Z';
+    const result = formatDateJalali(iso, { locale: 'en-US' });
+    expect(result).toBe('2024-03-20');
+  });
 });

--- a/packages/twenty-shared/src/utils/__tests__/isRtlLocale.test.ts
+++ b/packages/twenty-shared/src/utils/__tests__/isRtlLocale.test.ts
@@ -5,6 +5,7 @@ describe('isRtlLocale', () => {
     expect(isRtlLocale('fa')).toBe(true);
     expect(isRtlLocale('fa-IR')).toBe(true);
     expect(isRtlLocale('ar')).toBe(true);
+    expect(isRtlLocale('FA-IR')).toBe(true);
   });
 
   it('returns false for non-rtl locales', () => {

--- a/packages/twenty-shared/src/utils/validation/__tests__/isValidLocale.test.ts
+++ b/packages/twenty-shared/src/utils/validation/__tests__/isValidLocale.test.ts
@@ -7,8 +7,13 @@ describe('isValidLocale', () => {
     });
   });
 
+  it('should explicitly validate fa-IR locale', () => {
+    expect(isValidLocale('fa-IR')).toBe(true);
+  });
+
   it('should return false for invalid locales', () => {
     expect(isValidLocale('invalidLocale')).toBe(false);
+    expect(isValidLocale('fa')).toBe(false);
     expect(isValidLocale(null)).toBe(false);
   });
 });

--- a/packages/twenty-shared/src/utils/validation/__tests__/normalizeLocale.test.ts
+++ b/packages/twenty-shared/src/utils/validation/__tests__/normalizeLocale.test.ts
@@ -11,6 +11,7 @@ describe('normalizeLocale', () => {
     expect(normalizeLocale('en')).toBe('en');
     expect(normalizeLocale('fr-FR')).toBe('fr-FR');
     expect(normalizeLocale('es-ES')).toBe('es-ES');
+    expect(normalizeLocale('fa-IR')).toBe('fa-IR');
   });
 
   it('should handle case-insensitive matches', () => {
@@ -18,6 +19,7 @@ describe('normalizeLocale', () => {
     expect(normalizeLocale('fr-fr')).toBe('fr-FR');
     expect(normalizeLocale('es-es')).toBe('es-ES');
     expect(normalizeLocale('DE-de')).toBe('de-DE');
+    expect(normalizeLocale('fa-ir')).toBe('fa-IR');
   });
 
   it('should match just the language part if full locale not found', () => {
@@ -25,6 +27,7 @@ describe('normalizeLocale', () => {
     expect(normalizeLocale('fr')).toBe('fr-FR');
     expect(normalizeLocale('es')).toBe('es-ES');
     expect(normalizeLocale('de')).toBe('de-DE');
+    expect(normalizeLocale('fa')).toBe('fa-IR');
   });
 
   it('should handle language codes that might map to multiple locales', () => {


### PR DESCRIPTION
## Summary
- verify fa-IR works in locale validation and normalization
- extend RTL locale checks for case-insensitivity
- test Jalali formatter with LTR fallback

## Testing
- `npx --yes nx test twenty-shared` *(fails: Could not find Nx modules; have you run npm/yarn install?)*

------
https://chatgpt.com/codex/tasks/task_b_68bd38d99c10832d8f16ea1351914768