### PR TITLE
feat(emails): support RTL fonts

### DIFF
--- a/packages/twenty-emails/src/common-style.ts
+++ b/packages/twenty-emails/src/common-style.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @nx/workspace-no-hardcoded-colors */
 
+import { i18n } from '@lingui/core';
+import { isRtlLocale } from 'twenty-shared/utils';
+
 const grayScale = {
   gray100: '#000000',
   gray90: '#141414',
@@ -35,7 +38,11 @@ export const emailTheme = {
       inverted: grayScale.gray0,
       blue: colors.blue40,
     },
-    family: 'Trebuchet MS', // Google Inter not working, we need to use a web safe font, see https://templates.mailchimp.com/design/typography/
+    get family() {
+      return isRtlLocale(i18n.locale)
+        ? 'Vazirmatn, Trebuchet MS'
+        : 'Trebuchet MS';
+    }, // Google Inter not working, we need to use a web safe font, see https://templates.mailchimp.com/design/typography/
     weight: {
       regular: 400,
       bold: 600,

--- a/packages/twenty-emails/src/components/BaseEmail.tsx
+++ b/packages/twenty-emails/src/components/BaseEmail.tsx
@@ -1,6 +1,8 @@
 import { i18n, type Messages } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { Container, Html } from '@react-email/components';
+import { isRtlLocale } from 'twenty-shared/utils';
+import { emailTheme } from 'src/common-style';
 
 import { BaseHead } from 'src/components/BaseHead';
 import { Footer } from 'src/components/Footer';
@@ -93,9 +95,12 @@ export const BaseEmail = ({ children, width, locale }: BaseEmailProps) => {
 
   return (
     <I18nProvider i18n={i18n}>
-      <Html lang={locale}>
+      <Html lang={locale} dir={isRtlLocale(locale) ? 'rtl' : 'ltr'}>
         <BaseHead />
-        <Container width={width || 290}>
+        <Container
+          width={width || 290}
+          style={{ fontFamily: emailTheme.font.family }}
+        >
           <Logo />
           {children}
           <Footer />

--- a/packages/twenty-emails/src/components/BaseHead.tsx
+++ b/packages/twenty-emails/src/components/BaseHead.tsx
@@ -1,17 +1,46 @@
 import { Font, Head } from '@react-email/components';
+import { i18n } from '@lingui/core';
+import { isRtlLocale } from 'twenty-shared/utils';
 
 import { emailTheme } from 'src/common-style';
 
 export const BaseHead = () => {
+  const rtl = isRtlLocale(i18n.locale);
+
   return (
     <Head>
       <title>Twenty email</title>
-      <Font
-        fontFamily={emailTheme.font.family}
-        fallbackFontFamily="sans-serif"
-        fontStyle="normal"
-        fontWeight={emailTheme.font.weight.regular}
-      />
+      {rtl ? (
+        <>
+          <Font
+            fontFamily={emailTheme.font.family}
+            fallbackFontFamily="sans-serif"
+            fontStyle="normal"
+            fontWeight={emailTheme.font.weight.regular}
+            webFont={{
+              url: 'https://fonts.gstatic.com/s/vazirmatn/v15/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgzORc.ttf',
+              format: 'truetype',
+            }}
+          />
+          <Font
+            fontFamily={emailTheme.font.family}
+            fallbackFontFamily="sans-serif"
+            fontStyle="normal"
+            fontWeight={emailTheme.font.weight.bold}
+            webFont={{
+              url: 'https://fonts.gstatic.com/s/vazirmatn/v15/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklbY0ORc.ttf',
+              format: 'truetype',
+            }}
+          />
+        </>
+      ) : (
+        <Font
+          fontFamily={emailTheme.font.family}
+          fallbackFontFamily="sans-serif"
+          fontStyle="normal"
+          fontWeight={emailTheme.font.weight.regular}
+        />
+      )}
     </Head>
   );
 };

--- a/packages/twenty-emails/src/components/MainText.tsx
+++ b/packages/twenty-emails/src/components/MainText.tsx
@@ -6,14 +6,14 @@ type MainTextProps = {
   children: JSX.Element | JSX.Element[] | string;
 };
 
-const mainTextStyle = {
-  fontFamily: emailTheme.font.family,
-  fontSize: emailTheme.font.size.md,
-  fontWeight: emailTheme.font.weight.regular,
-  color: emailTheme.font.colors.primary,
-  lineHeight: emailTheme.font.lineHeight,
-};
-
 export const MainText = ({ children }: MainTextProps) => {
+  const mainTextStyle = {
+    fontFamily: emailTheme.font.family,
+    fontSize: emailTheme.font.size.md,
+    fontWeight: emailTheme.font.weight.regular,
+    color: emailTheme.font.colors.primary,
+    lineHeight: emailTheme.font.lineHeight,
+  } as const;
+
   return <Text style={mainTextStyle}>{children}</Text>;
 };

--- a/packages/twenty-emails/src/components/SubTitle.tsx
+++ b/packages/twenty-emails/src/components/SubTitle.tsx
@@ -6,14 +6,14 @@ type SubTitleProps = {
   value: JSX.Element | JSX.Element[] | string;
 };
 
-const subTitleStyle = {
-  fontFamily: emailTheme.font.family,
-  fontSize: emailTheme.font.size.lg,
-  fontWeight: emailTheme.font.weight.bold,
-  color: emailTheme.font.colors.highlighted,
-};
-
 export const SubTitle = ({ value }: SubTitleProps) => {
+  const subTitleStyle = {
+    fontFamily: emailTheme.font.family,
+    fontSize: emailTheme.font.size.lg,
+    fontWeight: emailTheme.font.weight.bold,
+    color: emailTheme.font.colors.highlighted,
+  } as const;
+
   return (
     <Heading style={subTitleStyle} as="h3">
       {value}

--- a/packages/twenty-emails/src/components/Title.tsx
+++ b/packages/twenty-emails/src/components/Title.tsx
@@ -6,14 +6,14 @@ type TitleProps = {
   value: JSX.Element | JSX.Element[] | string;
 };
 
-const titleStyle = {
-  fontFamily: emailTheme.font.family,
-  fontSize: emailTheme.font.size.xl,
-  fontWeight: emailTheme.font.weight.bold,
-  color: emailTheme.font.colors.highlighted,
-};
-
 export const Title = ({ value }: TitleProps) => {
+  const titleStyle = {
+    fontFamily: emailTheme.font.family,
+    fontSize: emailTheme.font.size.xl,
+    fontWeight: emailTheme.font.weight.bold,
+    color: emailTheme.font.colors.highlighted,
+  } as const;
+
   return (
     <Heading style={titleStyle} as="h1">
       {value}


### PR DESCRIPTION
## Summary
- set email `<Html>` direction based on locale
- load Vazirmatn for RTL locales and switch theme font family
- compute text styles after locale activation

## Testing
- `yarn nx lint twenty-emails` *(fails: YAMLException: bad indentation of a mapping entry)*
- `yarn nx test twenty-emails` *(fails: YAMLException: bad indentation of a mapping entry)*
- `npx prettier packages/twenty-emails/src/common-style.ts packages/twenty-emails/src/components/BaseEmail.tsx packages/twenty-emails/src/components/BaseHead.tsx packages/twenty-emails/src/components/MainText.tsx packages/twenty-emails/src/components/SubTitle.tsx packages/twenty-emails/src/components/Title.tsx -c`

------
https://chatgpt.com/codex/tasks/task_b_68bd3b0f105c832da112456c17fa273a