### PR TITLE
feat(export): support locale in PDF export

### DIFF
--- a/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/ExportNoteActionSingleRecordAction.tsx
+++ b/packages/twenty-front/src/modules/action-menu/actions/record-actions/single-record/components/ExportNoteActionSingleRecordAction.tsx
@@ -3,6 +3,7 @@ import { useSelectedRecordIdOrThrow } from '@/action-menu/actions/record-actions
 import { recordStoreFamilyState } from '@/object-record/record-store/states/recordStoreFamilyState';
 import { useRecoilValue } from 'recoil';
 import { isDefined } from 'twenty-shared/utils';
+import { i18n } from '@lingui/core';
 
 export const ExportNoteActionSingleRecordAction = () => {
   const recordId = useSelectedRecordIdOrThrow();
@@ -36,7 +37,7 @@ export const ExportNoteActionSingleRecordAction = () => {
       '@/action-menu/actions/record-actions/single-record/utils/exportBlockNoteEditorToPdf'
     );
 
-    await exportBlockNoteEditorToPdf(parsedBody, filename);
+    await exportBlockNoteEditorToPdf(parsedBody, filename, i18n.locale);
 
     // TODO later: implement DOCX export
     // const { exportBlockNoteEditorToDocx } = await import(


### PR DESCRIPTION
## Summary
- register Vazirmatn and set text direction for RTL PDF exports
- pass active locale when exporting notes to PDF

## Testing
- `yarn nx lint twenty-front` *(fails: YAMLException: bad indentation of a mapping entry)*
- `yarn nx test twenty-front` *(fails: YAMLException: bad indentation of a mapping entry)*

------
https://chatgpt.com/codex/tasks/task_b_68bd3c795c2c832da7c679287677a6e9