### PR TITLE
feat(rtl): use logical spacing properties

### DIFF
--- a/packages/twenty-front/src/loading/components/RightPanelSkeletonLoader.tsx
+++ b/packages/twenty-front/src/loading/components/RightPanelSkeletonLoader.tsx
@@ -12,11 +12,11 @@ const StyledMainContainer = styled.div`
   flex-direction: row;
   gap: 8px;
   min-height: 0;
-  padding-left: 0;
+  padding-inline-start: 0;
   width: 100%;
 
   @media (max-width: ${MOBILE_VIEWPORT}px) {
-    padding-left: 12px;
+    padding-inline-start: 12px;
     padding-bottom: 0;
   }
 `;

--- a/packages/twenty-front/src/pages/not-found/NotFound.tsx
+++ b/packages/twenty-front/src/pages/not-found/NotFound.tsx
@@ -23,7 +23,7 @@ const StyledBackDrop = styled.div`
   flex-direction: column;
   height: 100%;
   justify-content: center;
-  left: 0;
+  inset-inline-start: 0;
   position: fixed;
   top: 0;
   width: 100%;

--- a/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
+++ b/packages/twenty-front/src/pages/onboarding/CreateProfile.tsx
@@ -43,7 +43,7 @@ const StyledComboInputContainer = styled.div`
   display: flex;
   flex-direction: row;
   > * + * {
-    margin-left: ${({ theme }) => theme.spacing(4)};
+    margin-inline-start: ${({ theme }) => theme.spacing(4)};
   }
 `;
 

--- a/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
+++ b/packages/twenty-front/src/pages/settings/SettingsWorkspaceMembers.tsx
@@ -54,7 +54,7 @@ const StyledButtonContainer = styled.div`
   align-items: center;
   display: flex;
   flex-direction: row;
-  margin-left: ${({ theme }) => theme.spacing(3)};
+  margin-inline-start: ${({ theme }) => theme.spacing(3)};
 `;
 
 const StyledTable = styled(Table)<{ hasMoreRows?: boolean }>`
@@ -65,7 +65,7 @@ const StyledTable = styled(Table)<{ hasMoreRows?: boolean }>`
 const StyledIconWrapper = styled.div`
   display: flex;
   align-items: center;
-  margin-right: ${({ theme }) => theme.spacing(2)};
+  margin-inline-end: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledTextContainerWithEllipsis = styled.div`


### PR DESCRIPTION
## Summary
- replace left/right padding with logical equivalents in RightPanelSkeletonLoader
- use margin-inline and inset-inline properties in onboarding and settings pages
- swap absolute left positioning for logical inset-inline

## Testing
- `yarn nx lint twenty-front` *(fails: YAMLException bad indentation of a mapping entry)*
- `yarn nx test twenty-front` *(fails: YAMLException bad indentation of a mapping entry)*

------
https://chatgpt.com/codex/tasks/task_b_68bd5023f1cc832dbe10fbf87fe60c11