### PR TITLE
feat(i18n): add RTL chevron helper

### DIFF
--- a/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
+++ b/packages/twenty-front/src/modules/auth/sign-in-up/components/SignInUpGlobalScopeForm.tsx
@@ -31,6 +31,7 @@ import { isDefined } from 'twenty-shared/utils';
 import {
   Avatar,
   HorizontalSeparator,
+  IconChevronLeft,
   IconChevronRight,
   IconPlus,
 } from 'twenty-ui/display';
@@ -38,6 +39,7 @@ import { Loader } from 'twenty-ui/feedback';
 import { MainButton } from 'twenty-ui/input';
 import { type AvailableWorkspace } from '~/generated/graphql';
 import { getWorkspaceUrl } from '~/utils/getWorkspaceUrl';
+import { isRtl } from '~/localization/utils/isRtl';
 
 const StyledContentContainer = styled(motion.div)`
   margin-bottom: ${({ theme }) => theme.spacing(8)};
@@ -151,6 +153,7 @@ export const SignInUpGlobalScopeForm = () => {
   const availableWorkspaces = useRecoilValue(availableWorkspacesState);
   const theme = useTheme();
   const { t } = useLingui();
+  const ChevronIcon = isRtl() ? IconChevronLeft : IconChevronRight;
 
   const isRequestingCaptchaToken = useRecoilValue(
     isRequestingCaptchaTokenState,
@@ -231,7 +234,7 @@ export const SignInUpGlobalScopeForm = () => {
                       </StyledWorkspaceUrl>
                     </StyledWorkspaceTextContainer>
                     <StyledChevronIcon>
-                      <IconChevronRight size={theme.icon.size.md} />
+                      <ChevronIcon size={theme.icon.size.md} />
                     </StyledChevronIcon>
                   </StyledWorkspaceContent>
                 </StyledWorkspaceItem>
@@ -246,7 +249,7 @@ export const SignInUpGlobalScopeForm = () => {
                   <StyledWorkspaceName>{t`Create a workspace`}</StyledWorkspaceName>
                 </StyledWorkspaceTextContainer>
                 <StyledChevronIcon>
-                  <IconChevronRight size={theme.icon.size.md} />
+                  <ChevronIcon size={theme.icon.size.md} />
                 </StyledChevronIcon>
               </StyledWorkspaceContent>
             </StyledWorkspaceItem>

--- a/packages/twenty-front/src/modules/localization/utils/__tests__/isRtl.test.ts
+++ b/packages/twenty-front/src/modules/localization/utils/__tests__/isRtl.test.ts
@@ -1,0 +1,16 @@
+import { i18n } from '@lingui/core';
+import { isRtl } from '../isRtl';
+
+describe('isRtl', () => {
+  it('returns true for RTL locale', () => {
+    i18n.load('fa-IR', {});
+    i18n.activate('fa-IR');
+    expect(isRtl()).toBe(true);
+  });
+
+  it('returns false for LTR locale', () => {
+    i18n.load('en', {});
+    i18n.activate('en');
+    expect(isRtl()).toBe(false);
+  });
+});

--- a/packages/twenty-front/src/modules/localization/utils/isRtl.ts
+++ b/packages/twenty-front/src/modules/localization/utils/isRtl.ts
@@ -1,0 +1,7 @@
+import { i18n } from '@lingui/core';
+import { isRtlLocale } from 'twenty-shared/utils';
+
+/**
+ * Returns whether the currently active i18n locale is a RTL locale.
+ */
+export const isRtl = (): boolean => isRtlLocale(i18n.locale);

--- a/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
+++ b/packages/twenty-front/src/modules/settings/components/SettingsListItemCardContent.tsx
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 import { type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { isDefined } from 'twenty-shared/utils';
-import { IconChevronRight, type IconComponent } from 'twenty-ui/display';
+import { IconChevronLeft, IconChevronRight, type IconComponent } from 'twenty-ui/display';
+import { isRtl } from '~/localization/utils/isRtl';
 import { CardContent } from 'twenty-ui/layout';
 
 const StyledRow = styled(CardContent, {
@@ -30,12 +31,6 @@ const StyledRightContainer = styled.div`
   align-items: center;
   display: flex;
   gap: ${({ theme }) => theme.spacing(1)};
-`;
-
-const StyledIconChevronRight = styled(IconChevronRight)`
-  [dir='rtl'] & {
-    transform: scaleX(-1);
-  }
 `;
 
 const StyledContent = styled.div`
@@ -77,6 +72,7 @@ export const SettingsListItemCardContent = ({
   to,
 }: SettingsListItemCardContentProps) => {
   const theme = useTheme();
+  const ChevronIcon = isRtl() ? IconChevronLeft : IconChevronRight;
 
   const content = (
     <StyledRow onClick={onClick} divider={divider} to={!!to}>
@@ -93,7 +89,7 @@ export const SettingsListItemCardContent = ({
       <StyledRightContainer>
         {rightComponent}
         {!!to && (
-          <StyledIconChevronRight
+          <ChevronIcon
             size={theme.icon.size.md}
             color={theme.font.color.tertiary}
           />

--- a/packages/twenty-front/src/modules/ui/navigation/bread-crumb/components/MobileBreadcrumb.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/bread-crumb/components/MobileBreadcrumb.tsx
@@ -4,7 +4,8 @@ import styled from '@emotion/styled';
 import { isNonEmptyString } from '@sniptt/guards';
 import { type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { IconChevronLeft } from 'twenty-ui/display';
+import { IconChevronLeft, IconChevronRight } from 'twenty-ui/display';
+import { isRtl } from '~/localization/utils/isRtl';
 
 export type MobileBreadcrumbProps = {
   className?: string;
@@ -46,6 +47,8 @@ export const MobileBreadcrumb = ({
 
   const { openSettingsMenu } = useOpenSettingsMenu();
 
+  const ChevronIcon = isRtl() ? IconChevronRight : IconChevronLeft;
+
   const handleBackToSettingsClick = () => {
     openSettingsMenu();
   };
@@ -61,14 +64,14 @@ export const MobileBreadcrumb = ({
     <StyledWrapper className={className}>
       {shouldRedirectToSettings ? (
         <>
-          <IconChevronLeft size={theme.icon.size.md} />
+          <ChevronIcon size={theme.icon.size.md} />
           <StyledText onClick={handleBackToSettingsClick}>
             Back to Settings
           </StyledText>
         </>
       ) : previousLink?.href ? (
         <>
-          <IconChevronLeft size={theme.icon.size.md} />
+          <ChevronIcon size={theme.icon.size.md} />
           <StyledLink title={text} to={previousLink.href}>
             Back to {previousLink.children}
           </StyledLink>

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownAnyFieldSearchInputDropdownHeader.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownAnyFieldSearchInputDropdownHeader.tsx
@@ -2,7 +2,8 @@ import { useResetFilterDropdown } from '@/object-record/object-filter-dropdown/h
 import { DropdownMenuHeader } from '@/ui/layout/dropdown/components/DropdownMenuHeader/DropdownMenuHeader';
 import { DropdownMenuHeaderLeftComponent } from '@/ui/layout/dropdown/components/DropdownMenuHeader/internal/DropdownMenuHeaderLeftComponent';
 import { useLingui } from '@lingui/react/macro';
-import { IconChevronLeft } from 'twenty-ui/display';
+import { IconChevronLeft, IconChevronRight } from 'twenty-ui/display';
+import { isRtl } from '~/localization/utils/isRtl';
 
 export const ViewBarFilterDropdownAnyFieldSearchInputDropdownHeader = () => {
   const { t } = useLingui();
@@ -18,7 +19,7 @@ export const ViewBarFilterDropdownAnyFieldSearchInputDropdownHeader = () => {
       StartComponent={
         <DropdownMenuHeaderLeftComponent
           onClick={handleBackButtonClick}
-          Icon={IconChevronLeft}
+          Icon={isRtl() ? IconChevronRight : IconChevronLeft}
         />
       }
     >

--- a/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFilterInputMenuHeader.tsx
+++ b/packages/twenty-front/src/modules/views/components/ViewBarFilterDropdownFilterInputMenuHeader.tsx
@@ -7,7 +7,8 @@ import { useRecoilComponentValue } from '@/ui/utilities/state/component-state/ho
 import { useClearVectorSearchInput } from '@/views/hooks/useClearVectorSearchInput';
 import { useLingui } from '@lingui/react/macro';
 import { ViewFilterOperand } from 'twenty-shared/types';
-import { IconChevronLeft } from 'twenty-ui/display';
+import { IconChevronLeft, IconChevronRight } from 'twenty-ui/display';
+import { isRtl } from '~/localization/utils/isRtl';
 
 export const ViewBarFilterDropdownFilterInputMenuHeader = () => {
   const { t } = useLingui();
@@ -37,7 +38,7 @@ export const ViewBarFilterDropdownFilterInputMenuHeader = () => {
       StartComponent={
         <DropdownMenuHeaderLeftComponent
           onClick={handleBackButtonClick}
-          Icon={IconChevronLeft}
+          Icon={isRtl() ? IconChevronRight : IconChevronLeft}
         />
       }
     >

--- a/packages/twenty-front/src/pages/onboarding/BookCall.tsx
+++ b/packages/twenty-front/src/pages/onboarding/BookCall.tsx
@@ -11,8 +11,14 @@ import { ScrollWrapper } from '@/ui/utilities/scroll/components/ScrollWrapper';
 import { useTheme } from '@emotion/react';
 import { useLingui } from '@lingui/react/macro';
 import { useRecoilValue } from 'recoil';
-import { IconChevronLeft, IconChevronRightPipe } from 'twenty-ui/display';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronLeftPipe,
+  IconChevronRightPipe,
+} from 'twenty-ui/display';
 import { LightButton } from 'twenty-ui/input';
+import { isRtl } from '~/localization/utils/isRtl';
 import { useIsMobile } from 'twenty-ui/utilities';
 import {
   OnboardingStatus,
@@ -72,11 +78,14 @@ export const BookCall = () => {
       <StyledModalFooter>
         {isPlanRequired ? (
           <Link to={AppPath.PlanRequired}>
-            <LightButton Icon={IconChevronLeft} title={t`Back`} />
+            <LightButton
+              Icon={isRtl() ? IconChevronRight : IconChevronLeft}
+              title={t`Back`}
+            />
           </Link>
         ) : (
           <LightButton
-            Icon={IconChevronRightPipe}
+            Icon={isRtl() ? IconChevronLeftPipe : IconChevronRightPipe}
             title={t`Skip`}
             onClick={handleCompleteOnboarding}
           />

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemNavigate.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemNavigate.tsx
@@ -1,6 +1,8 @@
 import { useTheme } from '@emotion/react';
+import { i18n } from '@lingui/core';
+import { isRtlLocale } from 'twenty-shared/utils';
 
-import { IconChevronRight, type IconComponent } from '@ui/display';
+import { IconChevronLeft, IconChevronRight, type IconComponent } from '@ui/display';
 import { MenuItemLeftContent } from '../internals/components/MenuItemLeftContent';
 import {
   StyledMenuItemBase,
@@ -21,16 +23,14 @@ export const MenuItemNavigate = ({
   onClick,
 }: MenuItemNavigateProps) => {
   const theme = useTheme();
+  const ChevronIcon = isRtlLocale(i18n.locale) ? IconChevronLeft : IconChevronRight;
 
   return (
     <StyledMenuItemBase onClick={onClick} className={className}>
       <StyledMenuItemLeftContent>
         <MenuItemLeftContent LeftIcon={LeftIcon} text={text} />
       </StyledMenuItemLeftContent>
-      <IconChevronRight
-        size={theme.icon.size.sm}
-        color={theme.font.color.tertiary}
-      />
+      <ChevronIcon size={theme.icon.size.sm} color={theme.font.color.tertiary} />
     </StyledMenuItemBase>
   );
 };

--- a/packages/twenty-ui/src/navigation/menu-item/components/MenuItemSelect.tsx
+++ b/packages/twenty-ui/src/navigation/menu-item/components/MenuItemSelect.tsx
@@ -1,7 +1,14 @@
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { i18n } from '@lingui/core';
+import { isRtlLocale } from 'twenty-shared/utils';
 
-import { IconCheck, IconChevronRight, type IconComponent } from '@ui/display';
+import {
+  IconCheck,
+  IconChevronLeft,
+  IconChevronRight,
+  type IconComponent,
+} from '@ui/display';
 import { type ReactNode } from 'react';
 import { MenuItemLeftContent } from '../internals/components/MenuItemLeftContent';
 import { StyledMenuItemBase } from '../internals/components/StyledMenuItemBase';
@@ -56,6 +63,7 @@ export const MenuItemSelect = ({
   contextualText,
 }: MenuItemSelectProps) => {
   const theme = useTheme();
+  const ChevronIcon = isRtlLocale(i18n.locale) ? IconChevronLeft : IconChevronRight;
 
   return (
     <StyledMenuItemSelect
@@ -75,10 +83,7 @@ export const MenuItemSelect = ({
       {selected && needIconCheck && <IconCheck size={theme.icon.size.md} />}
 
       {hasSubMenu && (
-        <IconChevronRight
-          size={theme.icon.size.sm}
-          color={theme.font.color.tertiary}
-        />
+        <ChevronIcon size={theme.icon.size.sm} color={theme.font.color.tertiary} />
       )}
     </StyledMenuItemSelect>
   );


### PR DESCRIPTION
## Summary
- add `isRtl` helper for current locale
- flip chevron icons based on RTL in navigation components
- cover new helper with unit tests

## Testing
- `yarn nx test twenty-front --testFile=packages/twenty-front/src/modules/localization/utils/__tests__/isRtl.test.ts --runInBand` *(fails: YAMLException: bad indentation of a mapping entry)*
- `yarn nx test twenty-ui --testFile=packages/twenty-ui/src/navigation/menu-item/components/MenuItemNavigate.tsx --runInBand` *(fails: YAMLException: bad indentation of a mapping entry)*

------
https://chatgpt.com/codex/tasks/task_b_68bd5202e824832d82289aa452eb4c35