### PR TITLE
fix(deps): remove duplicate date-fns-jalali entry

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4,6 +4,3 @@
   checksum: 10c0/f9ad98d9f7e8e5abe0d070dc806b0c8baded2b1208626c42e92cbd2605b5171f5714d6b79b20cc2666267d821699244c9d0b5e93274106cf57d6232da77596ed
   languageName: node
   linkType: hard
-
-    date-fns-jalali: "npm:^4.1.0-0"
-    date-fns-jalali: "npm:^4.1.0-0"


### PR DESCRIPTION
## Summary
- remove duplicate date-fns-jalali entry from `yarn.lock`

## Testing
- `yarn install` *(fails: Node version v20.19.4 doesn't match required ^24.5.0)*
- `yarn lint` *(fails: package not present in lockfile; run `yarn install`)*

------
https://chatgpt.com/codex/tasks/task_b_68bda93a9130832d9bc4e8721fe39c70