### PR TITLE
fix(record-table): use row ref for intersection observer

### DIFF
--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTr.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableDraggableTr.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react';
 import { Draggable } from '@hello-pangea/dnd';
-import { type ReactNode } from 'react';
+import { type ReactNode, useRef } from 'react';
 
 import { useRecordTableContextOrThrow } from '@/object-record/record-table/contexts/RecordTableContext';
 import { RecordTableRowDraggableContextProvider } from '@/object-record/record-table/contexts/RecordTableRowDraggableContext';
@@ -8,6 +8,7 @@ import { useRecordDragState } from '@/object-record/record-drag/shared/hooks/use
 import { RecordTableRowMultiDragPreview } from '@/object-record/record-table/record-table-row/components/RecordTableRowMultiDragPreview';
 import { RecordTableTr } from '@/object-record/record-table/record-table-row/components/RecordTableTr';
 import { RecordTableTrEffect } from '@/object-record/record-table/record-table-row/components/RecordTableTrEffect';
+import { combineRefs } from '~/utils/combineRefs';
 
 type RecordTableDraggableTrProps = {
   className?: string;
@@ -32,6 +33,8 @@ export const RecordTableDraggableTr = ({
   const { recordTableId } = useRecordTableContextOrThrow();
   const multiDragState = useRecordDragState('table', recordTableId);
 
+  const rowRef = useRef<HTMLTableRowElement | null>(null);
+
   const isSecondaryDragged =
     multiDragState?.isDragging &&
     multiDragState.originalSelection.includes(recordId) &&
@@ -43,46 +46,53 @@ export const RecordTableDraggableTr = ({
       index={draggableIndex}
       isDragDisabled={isDragDisabled}
     >
-      {(draggableProvided, draggableSnapshot) => (
-        <>
-          <RecordTableTrEffect recordId={recordId} />
-          <RecordTableTr
-            recordId={recordId}
-            focusIndex={focusIndex}
-            ref={draggableProvided.innerRef}
-            className={className}
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...draggableProvided.draggableProps}
-            style={{
-              ...draggableProvided.draggableProps.style,
-              background: draggableSnapshot.isDragging
-                ? theme.background.transparent.light
-                : undefined,
-              borderColor: draggableSnapshot.isDragging
-                ? `${theme.border.color.medium}`
-                : 'transparent',
-              opacity: isSecondaryDragged ? 0.3 : 1,
-            }}
-            isDragging={draggableSnapshot.isDragging}
-            data-testid={`row-id-${recordId}`}
-            data-virtualized-id={recordId}
-            data-selectable-id={recordId}
-            onClick={onClick}
-          >
-            <RecordTableRowDraggableContextProvider
-              value={{
-                isDragging: draggableSnapshot.isDragging,
-                dragHandleProps: draggableProvided.dragHandleProps,
+      {(draggableProvided, draggableSnapshot) => {
+        const ref = combineRefs<HTMLTableRowElement>(
+          rowRef,
+          draggableProvided.innerRef,
+        );
+
+        return (
+          <>
+            <RecordTableTrEffect recordId={recordId} rowRef={rowRef} />
+            <RecordTableTr
+              recordId={recordId}
+              focusIndex={focusIndex}
+              ref={ref}
+              className={className}
+              // eslint-disable-next-line react/jsx-props-no-spreading
+              {...draggableProvided.draggableProps}
+              style={{
+                ...draggableProvided.draggableProps.style,
+                background: draggableSnapshot.isDragging
+                  ? theme.background.transparent.light
+                  : undefined,
+                borderColor: draggableSnapshot.isDragging
+                  ? `${theme.border.color.medium}`
+                  : 'transparent',
+                opacity: isSecondaryDragged ? 0.3 : 1,
               }}
+              isDragging={draggableSnapshot.isDragging}
+              data-testid={`row-id-${recordId}`}
+              data-virtualized-id={recordId}
+              data-selectable-id={recordId}
+              onClick={onClick}
             >
-              {children}
-              <RecordTableRowMultiDragPreview
-                isDragging={draggableSnapshot.isDragging}
-              />
-            </RecordTableRowDraggableContextProvider>
-          </RecordTableTr>
-        </>
-      )}
+              <RecordTableRowDraggableContextProvider
+                value={{
+                  isDragging: draggableSnapshot.isDragging,
+                  dragHandleProps: draggableProvided.dragHandleProps,
+                }}
+              >
+                {children}
+                <RecordTableRowMultiDragPreview
+                  isDragging={draggableSnapshot.isDragging}
+                />
+              </RecordTableRowDraggableContextProvider>
+            </RecordTableTr>
+          </>
+        );
+      }}
     </Draggable>
   );
 };

--- a/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTrEffect.tsx
+++ b/packages/twenty-front/src/modules/object-record/record-table/record-table-row/components/RecordTableTrEffect.tsx
@@ -1,13 +1,17 @@
 import { isRowVisibleComponentFamilyState } from '@/object-record/record-table/record-table-row/states/isRowVisibleComponentFamilyState';
 import { useScrollWrapperElement } from '@/ui/utilities/scroll/hooks/useScrollWrapperElement';
 import { useSetRecoilComponentFamilyState } from '@/ui/utilities/state/component-state/hooks/useSetRecoilComponentFamilyState';
-import { useEffect } from 'react';
+import { type RefObject, useEffect } from 'react';
 
 type RecordTableTrEffectProps = {
   recordId: string;
+  rowRef: RefObject<HTMLTableRowElement>;
 };
 
-export const RecordTableTrEffect = ({ recordId }: RecordTableTrEffectProps) => {
+export const RecordTableTrEffect = ({
+  recordId,
+  rowRef,
+}: RecordTableTrEffectProps) => {
   const { scrollWrapperHTMLElement } = useScrollWrapperElement();
 
   const setIsRowVisible = useSetRecoilComponentFamilyState(
@@ -38,16 +42,14 @@ export const RecordTableTrEffect = ({ recordId }: RecordTableTrEffectProps) => {
 
     const observer = new IntersectionObserver(callback, options);
 
-    observer.observe(
-      document.querySelector(
-        `[data-virtualized-id="${recordId}"]`,
-      ) as HTMLElement,
-    );
+    if (rowRef.current) {
+      observer.observe(rowRef.current);
+    }
 
     return () => {
       observer.disconnect();
     };
-  }, [recordId, scrollWrapperHTMLElement, setIsRowVisible]);
+  }, [recordId, rowRef, scrollWrapperHTMLElement, setIsRowVisible]);
 
   return <></>;
 };


### PR DESCRIPTION
## Summary
- use row ref for visibility observer instead of query selector
- forward row ref from draggable row

## Testing
- `yarn nx test twenty-front` *(fails: Internal Error: twenty@workspace:.: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68bdabb70df0832db950e02c0ccdc705