### PR TITLE
fix(ui): guard animated placeholder event listeners

### DIFF
--- a/packages/twenty-ui/src/utilities/events/hooks/useEventListener.ts
+++ b/packages/twenty-ui/src/utilities/events/hooks/useEventListener.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+export const useEventListener = <K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: (event: WindowEventMap[K]) => void,
+  element?: Window | Document | HTMLElement | null,
+) => {
+  useEffect(() => {
+    const target =
+      element ?? (typeof window !== 'undefined' ? window : undefined);
+
+    if (!target) return;
+
+    const listener = (event: Event) => {
+      handler(event as WindowEventMap[K]);
+    };
+
+    target.addEventListener(eventName, listener);
+
+    return () => {
+      target.removeEventListener(eventName, listener);
+    };
+  }, [eventName, handler, element]);
+};


### PR DESCRIPTION
## Summary
- avoid window access during AnimatedPlaceholder render by initializing motion values at 0 and setting them in `useEffect`
- add `useEventListener` hook to attach and clean up mouse/touch events
- guard event listeners for SSR

## Testing
- `nx lint twenty-ui` *(fails: Cannot find module 'chalk')*
- `nx test twenty-ui` *(fails: Cannot find module 'chalk')*


------
https://chatgpt.com/codex/tasks/task_b_68bdaea74030832da42b0fd3577e2961